### PR TITLE
Silence webpack build error and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # Teamwork capstone project
 
 This is a learning repo for [react](https://reactjs.org/) and [express](https://expressjs.com/)
+
+## Instructions
+
+1. Build run ``` yarn build ```
+2. Start a package e.g api: ``` name=api yarn debug ```
+

--- a/packages/teamwork-capstone-api/package.json
+++ b/packages/teamwork-capstone-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "teamwork-capstone-api",
+  "name": "@teamwork/capstone-api",
   "version": "0.1.0",
   "main": "index.js",
   "license": "MIT",

--- a/packages/teamwork-capstone-api/src/index.ts
+++ b/packages/teamwork-capstone-api/src/index.ts
@@ -17,6 +17,14 @@ app.use(helmet());
 app.use(cors());
 app.use(express.json());
 
+app.get("/", (req, res) => {
+  const headers  = req.headers;
+  console.log(headers);
+  res
+    .send({ username: "donaldkibet", url: "https://github.com/donaldkibet" })
+    .status(200);
+});
+
 const server = app.listen(PORT, () => {
   console.log(`Server Listening at port ${PORT}`);
 });


### PR DESCRIPTION
### What this PR does?

This PR silences webpack build warning on Circular dependency and update README to include build instructions using wepback


### How can this manually tested

1. Clone this PR and run ``` lerna bootstrap ``` to install dependencies ﻿
2. On the terminal run ``` name=api yarn debug ``` to spin up localserve

You should not see any webpack warning
